### PR TITLE
Switch from AppVeyor to GitHub Actions

### DIFF
--- a/.github/workflows/UpdateAssemblyInfo.ps1
+++ b/.github/workflows/UpdateAssemblyInfo.ps1
@@ -1,0 +1,42 @@
+# Parse version number from source control tags
+$VersionRegex = "\d+\.\d+\.\d+(\.\d+)?"
+$VersionNumber = [regex]::matches($Env:BUILD_VERSION, $VersionRegex)[0]
+
+if(!$VersionNumber.Success)
+{
+    Write-Error "Couldn't parse semantic version from tag: $Env:BUILD_VERSION"
+}
+
+if(!$VersionNumber.Groups[1].Success)
+{
+    # MSBuild expects 4 part version numbers; add build number from GitHub Actions
+    $VersionNumber = "$VersionNumber.${Env:GITHUB_RUN_NUMBER}"
+}
+
+Write-Host "Source version number: $Env:BUILD_VERSION"
+Write-Host "Parsed version number: $VersionNumber"
+
+# Get friendly-length commit hash
+$CommitHash = $Env:GITHUB_SHA.Substring(0, 7)
+
+# Find every AssemblyInfo.cs
+$files = Get-ChildItem -Path "${Env:GITHUB_WORKSPACE}\**\Properties" -Recurse -include "AssemblyInfo.*"
+
+# Update version number in AssemblyInfo.cs
+if($files)
+{
+    foreach ($file in $files) {
+        Write-Host "Updating version in $file"
+        # Disable Read-Only
+        attrib $file -r
+        # Find and Replace in AssemblyInfo.cs
+        $content = Get-Content($file)
+        $content -replace $VersionRegex, $VersionNumber | Out-File $file
+        # Append Informational Version with commit hash; appears as "Product Version"
+        "[assembly: AssemblyInformationalVersion(`"$VersionNumber-$CommitHash`")]" >> $file
+    }
+}
+else
+{
+    Write-Warning "Couldn't find any AssemblyInfo files to update!"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "Build"
 on:
   push:
     tags: 
-      - "v*"
+      - "*"
 
 jobs:
   tagged-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: "Build"
+on:
+  push:
+    tags: 
+      - "v*"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "windows-latest"
+    
+    steps:
+    - name: "Checkout"
+      uses: "actions/checkout@v2"
+      
+    - name: "Process Version from Tag"
+      id: "version"
+      uses: "ncipollo/semantic-version-action@v1"
+    
+    - name: "Update Version in AssemblyInfo.cs"
+      env:
+        BUILD_VERSION: "${{ steps.version.outputs.tag }}"
+      shell: "powershell"
+      run: |
+        .\.github\workflows\UpdateAssemblyInfo.ps1
+    
+    - name: "Write Version to Text File"
+      env:
+        BUILD_VERSION: "${{ steps.version.outputs.tag }}"
+      shell: "powershell"
+      run: |
+        echo "source: ${Env:GITHUB_REPOSITORY}" > "${Env:GITHUB_WORKSPACE}\VERSION.md"
+        echo "version: ${Env:BUILD_VERSION}" >> "${Env:GITHUB_WORKSPACE}\VERSION.md"
+        echo "commit: ${Env:GITHUB_SHA}" >> "${Env:GITHUB_WORKSPACE}\VERSION.md"
+        echo "date: $((Get-Date -format r).ToString())" >> "${Env:GITHUB_WORKSPACE}\VERSION.md"
+    
+    - name: "Install NuGet"
+      uses: "nuget/setup-nuget@v1"
+    
+    - name: "Configure NuGet Sources"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      shell: "powershell"
+      run: |
+        nuget sources add -Name "GitHub/${Env:GITHUB_ACTOR}" -Source "https://nuget.pkg.github.com/${Env:GITHUB_ACTOR}/index.json" -UserName "${Env:GITHUB_ACTOR}" -Password "${Env:GITHUB_TOKEN}"
+
+    - uses: "actions/cache@v1"
+      id: "cache"
+      with:
+        path: "${{ github.workspace }}/.nuget/packages"
+        key: "${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}"
+
+    - name: "Restore NuGet Packages"
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: "powershell"
+      run: |
+        nuget restore -LockedMode ${Env:GITHUB_WORKSPACE}
+
+    - name: "Build with .NET Framework 3.5"
+      shell: "powershell"
+      run: |
+        cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
+        .\MSBuild.exe "${Env:GITHUB_WORKSPACE}\" /p:RestoreLockedMode=true /p:Configuration=Release
+    
+    - name: "Package Artifacts"
+      env:
+        BUILD_VERSION: "${{ steps.version.outputs.tag }}"
+      shell: "powershell"
+      run: |
+        $COMMIT_HASH = $Env:GITHUB_SHA.Substring(0, 7)
+        7z a PulsarPluginBootstrapper-${Env:BUILD_VERSION}-${COMMIT_HASH}.zip README.md VERSION.md .\PulsarInjector\bin\Release\* -xr!*.pdb -mx=7
+        7z a PulsarPluginLoader.dll-${Env:BUILD_VERSION}-${COMMIT_HASH}.zip README.md VERSION.md .\PulsarPluginLoader\bin\Release\PulsarPluginLoader.dll -mx=7
+    
+    - name: "Publish to GitHub Releases"
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: false
+        files: |
+          *.zip

--- a/PulsarPluginLoader.Tests/PulsarPluginLoader.Tests.csproj
+++ b/PulsarPluginLoader.Tests/PulsarPluginLoader.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,8 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.0.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lib.Harmony.2.0.2\lib\net472\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,8 +49,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.11.0\lib\net40\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Pathfinding.Ionic.Zip.Reduced">
       <HintPath>..\lib\Pathfinding.Ionic.Zip.Reduced.dll</HintPath>
@@ -60,6 +61,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -114,6 +116,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
   </Target>
 </Project>

--- a/PulsarPluginLoader.Tests/packages.config
+++ b/PulsarPluginLoader.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.0.1" targetFramework="net40" />
-  <package id="NUnit" version="3.11.0" targetFramework="net40" />
+  <package id="Lib.Harmony" version="2.0.2" targetFramework="net472" />
+  <package id="NUnit" version="3.12.0" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net472" />
 </packages>

--- a/PulsarPluginLoader.sln
+++ b/PulsarPluginLoader.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PulsarPluginLoader", "PulsarPluginLoader\PulsarPluginLoader.csproj", "{CF6CE9BA-9603-439D-9173-96C052C94417}"
 EndProject
@@ -9,9 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PulsarInjector", "PulsarInj
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6FA95747-6271-4991-96D0-73EDCA21D402}"
 	ProjectSection(SolutionItems) = preProject
-		appveyor.yml = appveyor.yml
+		.github\workflows\build.yml = .github\workflows\build.yml
 		LICENSE = LICENSE
 		README.md = README.md
+		.github\workflows\UpdateAssemblyInfo.ps1 = .github\workflows\UpdateAssemblyInfo.ps1
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PulsarPluginLoader.Tests", "PulsarPluginLoader.Tests\PulsarPluginLoader.Tests.csproj", "{9ACD22DC-0BEB-44AB-A012-D93E993D75F3}"

--- a/PulsarPluginLoader/PulsarPluginLoader.csproj
+++ b/PulsarPluginLoader/PulsarPluginLoader.csproj
@@ -34,8 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.0.1\lib\net472\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lib.Harmony.2.0.2\lib\net472\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="ACTk.Runtime, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/PulsarPluginLoader/packages.config
+++ b/PulsarPluginLoader/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.0.1" targetFramework="net472" />
+  <package id="Lib.Harmony" version="2.0.2" targetFramework="net472" />
   <package id="Mono.Cecil" version="0.11.2" targetFramework="net472" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/jkary3fagowm4adm/branch/master?svg=true)](https://ci.appveyor.com/project/TomRichter/pulsar-plugin-loader/branch/master)
+[![Build](https://github.com/TomRichter/pulsar-plugin-loader/workflows/Build/badge.svg)](#)
 
 # [PULSAR Plugin Loader](https://github.com/TomRichter/pulsar-plugin-loader)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
-[![Build](https://github.com/TomRichter/pulsar-plugin-loader/workflows/Build/badge.svg)](#)
+# [PULSAR Plugin Loader][0]
 
-# [PULSAR Plugin Loader](https://github.com/TomRichter/pulsar-plugin-loader)
 
-Injects a basic plugin loader into [*PULSAR: Lost Colony*](http://www.pulsarthegame.com/).
+[0]: https://github.com/PULSAR-Modders/pulsar-plugin-loader "PULSAR Plugin Loader"
 
-Contact us on our discord! [Pulsar Lost Colony: Crew Matchup Server](https://discord.gg/yBJGv4T)
+[![Build Status][1]][2]
+[![Download][3]][4]
+[![Wiki][5]][6]
+[![Discord][7]][8]
+
+[1]: https://github.com/PULSAR-Modders/pulsar-plugin-loader/workflows/Build/badge.svg
+[2]: https://github.com/PULSAR-Modders/pulsar-plugin-loader/actions "Build Status"
+[3]: https://img.shields.io/badge/-DOWNLOAD-success
+[4]: https://github.com/PULSAR-Modders/pulsar-plugin-loader/packages "Download"
+[5]: https://img.shields.io/badge/-WIKI-informational
+[6]: https://github.com/PULSAR-Modders/pulsar-plugin-loader/wiki "Wiki"
+[7]: https://img.shields.io/discord/458244416562397184.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2
+[8]: https://discord.gg/yBJGv4T "PPL Discord"
+
+Injects a basic plugin loader into [*PULSAR: Lost Colony*][10].
+
+[10]: http://www.pulsarthegame.com/ "PULSAR: Lost Colony"
 
 ## Usage
 
@@ -26,7 +41,10 @@ Optionally remove `PulsarPluginLoader.dll`, `Assembly-CSharp.dll.bak`, and the `
 
 ## Creating Plugins
 
-All plugins must be C# Class Libraries targeting .NET Framework 4.0 or later (to work around some jankery).  See [this screenshot](https://i.imgur.com/X7bDnYr.png) for an example of project creation settings in Visual Studio Community 2019 ([free download](https://visualstudio.microsoft.com/vs/community/)).
+All plugins must be C# Class Libraries targeting .NET Framework 4.0 or later (to work around some jankery).  See [this screenshot][11] for an example of project creation settings in Visual Studio Community 2019 ([free download][12]).
+
+[11]: https://i.imgur.com/X7bDnYr.png "New Project"
+[12]: https://visualstudio.microsoft.com/vs/community/ "Visual Studio 2019"
 
 You Should reference the following assemblies in your plugin project:
 
@@ -53,7 +71,9 @@ class MyPlugin : PulsarPlugin
 }
 ```
 
-Using [`Harmony`](https://github.com/pardeike/Harmony) to hook PULSAR methods is strongly recommended due to its simple API and tools that help multiple plugins play nicely when modifying the same methods (stacking hooks instead of overwriting each other, prioritization, etc).  Any class using Harmony decorators will magically hook their methods.
+Using [`HarmonyLib`] to hook PULSAR methods is strongly recommended due to its simple API and tools that help multiple plugins play nicely when modifying the same methods (stacking hooks instead of overwriting each other, prioritization, etc).  Any class using Harmony decorators will magically hook their methods.
+
+[13]: https://github.com/pardeike/Harmony "HarmonyLib"
 
 ### Basic Plugin Example
 
@@ -90,4 +110,4 @@ namespace ExamplePlugin
 }
 ```
 
-Distribute plugins as `.dll` assemblies.  To install, simply drop the assembly into the `Plugins` folder; any properly-defined `*.dll` plugin assemblies are automatically loaded.
+Distribute plugins as `.dll` assemblies.  To install, simply drop the assembly into the `Managed\Plugins` folder; any properly-defined `*.dll` plugin assemblies are automatically loaded.


### PR DESCRIPTION
Using GH Actions should be less fragile when forking, and easier to manage since it's all on GitHub rather than multiple sites you need to Just Know About.